### PR TITLE
Pantalla HomeScreen con estructura Scaffold

### DIFF
--- a/app/src/main/java/com/example/libreriasfiterror/MainActivity.kt
+++ b/app/src/main/java/com/example/libreriasfiterror/MainActivity.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import com.example.libreriasfiterror.ui.NavegacionApp
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -19,12 +20,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             LibreriaSfiterrorTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                NavegacionApp()
             }
         }
     }

--- a/app/src/main/java/com/example/libreriasfiterror/ui/HomeScreen.kt
+++ b/app/src/main/java/com/example/libreriasfiterror/ui/HomeScreen.kt
@@ -1,0 +1,45 @@
+package com.example.libreriasfiterror.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.libreriasfiterror.viewmodel.LibroViewModel
+
+@Composable
+fun HomeScreen() {
+    val viewModel: LibroViewModel = viewModel()
+    val listaLibros = viewModel.libros.observeAsState(initial = emptyList())
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("Libros SFIterror") })
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(listaLibros.value) { libro ->
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    elevation = 4.dp
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(text = libro.titulo, style = MaterialTheme.typography.h6)
+                        Text(text = "Autor: ${libro.autor}", style = MaterialTheme.typography.body2)
+                        Text(text = "Precio: $${libro.precio}", style = MaterialTheme.typography.body2)
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/libreriasfiterror/ui/Navegacion.kt
+++ b/app/src/main/java/com/example/libreriasfiterror/ui/Navegacion.kt
@@ -1,0 +1,12 @@
+package com.example.libreriasfiterror.ui
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun NavegacionApp() {
+    val navController = rememberNavController()
+    NavHost(navController, startDestination = "home") {
+        composable("home") { HomeScreen() }
+        // Agregar más pantallas aquí mas adelante
+    }
+}


### PR DESCRIPTION
Este pull request incluye la implementación de la pantalla HomeScreen utilizando la estructura Scaffold en Jetpack Compose.
Se creó la navegación básica en Compose con la función NavegacionApp para mostrar HomeScreen como pantalla inicial.
Esta funcionalidad corresponde a la evidencia de la sección 2.1.4 de la guía del proyecto, y forma parte del trabajo colaborativo.

Cambios principales:

Archivo HomeScreen.kt con la pantalla base.

Archivo Navegacion.kt con la navegación Compose.

Actualización en MainActivity.kt para iniciar con la navegación.

Esta implementación sienta la base para continuar el desarrollo del proyecto con arquitectura MVVM y navegación moderna.